### PR TITLE
Reusing samples from lower dimensional cases to improve performance

### DIFF
--- a/distance.c
+++ b/distance.c
@@ -69,11 +69,55 @@ int main( int argc, char **argv )
         }
     }
 
+
     // Initialize random seed
     srand(time(0));
 
+    // Initialize totals to zero
+    double totals[Dimensions+1][Powers];
+    int d,p;
+    for (d=0; d <= Dimensions; ++d) {
+        for (p=0; p<Powers; ++p) {
+            totals[d][p] = 0.;
+        }
+    }
+
+    // zero out the first row (i.e. zero dimensional case) of the sums
+    double sums[Dimensions+1][Powers];
+    for (p=0; p<Powers; ++p) {
+        sums[0][p] = 0.;
+    }
+
+    // Generate and add up sums of coordinate differences at various dimensions
+    // from two randomly generated points in the hypercube.
+    for (long r = 0; r < Randoms; ++r) {
+        // fill in the sum of powers for a single sample at various dimensions
+        // and powers.
+        for (d=1; d <= Dimensions; ++d) {
+            // For each dimension, get 2 coordinates in this dimension.
+            // we only care about dx, the delta in the coordinate
+            // use abs value for odd powers calculation
+            double dx, dx_cumprod;
+            dx = fabs((rand() - rand()) * scale);
+
+            // for each power, the sum will be the entry from the row above
+            // plus dx raised to that power.
+            double cumprod = 1;
+            for (p=0; p<Powers; ++p) {
+                cumprod *= dx;
+                sums[d][p] = sums[d-1][p] + cumprod;
+            }
+        }
+
+        // Add the pth root of each sum to the totals
+        for (d=1; d <= Dimensions; ++d) {
+            for (p=0; p<Powers; ++p) {
+                totals[d][p] += pow(sums[d][p], 1./(p+1));
+            }
+        }
+    }
+
     // Title line
-    int p ;
     printf("DIM\\Power, ");
     for (p=1;p<=Powers;++p) {
         printf("%d, ",p);
@@ -81,65 +125,25 @@ int main( int argc, char **argv )
     printf("\n");
 
     // Loop though dimensions
-    int d ;
-    for ( d=1 ; d <= Dimensions ; ++d ) {
-        double sum[Powers] ;
-        int p ;
-
+    for (d=1; d <= Dimensions; ++d) {
         // Start line with dimension
         printf("%d, ",d);
 
-        // zero out sums
+        // Print out the distances
         for (p=0;p<Powers;++p) {
-            sum[p] = 0. ;
-        }
-
-        // Random segments (i.e. 2 points of increasing dimension)
-        long r ;
-        for (r = 0 ; r < Randoms ; ++r ) {
-
-            // Zero out segment
-            double seg[Powers];
-            for (p=0;p<Powers;++p) {
-                seg[p] = 0. ;
-            }
-
-            // Add up for this dimension
-            int dd ;
-            for (dd = 0 ; dd < d ; ++dd) {
-                double sx = 1. ;
-                // For each dimension, get 2 coordinates in this dimension -- rand() and rand() scaled
-                // we only care about dx, the delta in the coordinate
-                // use abs value for odd powers calculation
-                double dx = fabs((rand() - rand()) * scale ) ;
-                // compute increasing powers of dx the easy way
-                for (p=0;p<Powers;++p) {
-                    sx *= dx ;
-                    seg[p] += sx ;
+            if (Normalize) {
+                for (p=0;p<Powers;++p){
+                    // note p is 0-indexed in C, but 1-indexed for calculation
+                    printf("%g, ", totals[d][p]/Randoms/pow(d,1/(1.+p)));
+                }
+            } else {
+                for (p=0;p<Powers;++p){
+                    printf("%g, ", totals[d][p]/Randoms);
                 }
             }
-
-            // Add segments to sum, taking the appropriate root
-            sum[0] += seg[0] ; // Manhattan or Taxi
-            sum[1] += sqrt(seg[1]) ; // Euclidean
-            for (p=2;p<Powers;++p) { // this is why Powers must be 3 or higher
-                // note p is 0-indexed in C, but 1-indexed for calculation
-                sum[p] += pow(seg[p],1/(1.+p));
-            }
+            // finish line
+            printf("\n");
         }
-
-        if (Normalize) {
-            for (p=0;p<Powers;++p){
-                // note p is 0-indexed in C, but 1-indexed for calculation
-                printf("%g, ",sum[p]/Randoms/pow(d,1/(1.+p)));
-            }
-        } else {
-            for (p=0;p<Powers;++p){
-                printf("%g, ",sum[p]/Randoms);
-            }
-        }
-        // finish line
-        printf("\n");
     }
 
     // success

--- a/distance.c
+++ b/distance.c
@@ -26,15 +26,15 @@ void help( void )
     printf("\t-n\tnormalize (to longest diagonal)\n");
     printf("\t-h\tthis help\n");
     exit(0) ;
-}    
+}
 
-int main( int argc, char **argv ) 
+int main( int argc, char **argv )
 {
     int Dimensions = 100 ;
     int Powers = 3 ;
     long Randoms = 1000000 ;
     int Normalize = 0;
-    
+
     double scale = 1.0 / RAND_MAX ;
 
 
@@ -71,7 +71,7 @@ int main( int argc, char **argv )
 
     // Initialize random seed
     srand(time(0));
-    
+
     // Title line
     int p ;
     printf("DIM\\Power, ");
@@ -85,25 +85,25 @@ int main( int argc, char **argv )
     for ( d=1 ; d <= Dimensions ; ++d ) {
         double sum[Powers] ;
         int p ;
-        
+
         // Start line with dimension
         printf("%d, ",d);
-        
+
         // zero out sums
-        for (p=0;p<Powers;++p) { 
+        for (p=0;p<Powers;++p) {
             sum[p] = 0. ;
         }
-        
+
         // Random segments (i.e. 2 points of increasing dimension)
         long r ;
         for (r = 0 ; r < Randoms ; ++r ) {
-            
+
             // Zero out segment
             double seg[Powers];
             for (p=0;p<Powers;++p) {
                 seg[p] = 0. ;
             }
-            
+
             // Add up for this dimension
             int dd ;
             for (dd = 0 ; dd < d ; ++dd) {
@@ -118,7 +118,7 @@ int main( int argc, char **argv )
                     seg[p] += sx ;
                 }
             }
-            
+
             // Add segments to sum, taking the appropriate root
             sum[0] += seg[0] ; // Manhattan or Taxi
             sum[1] += sqrt(seg[1]) ; // Euclidean
@@ -141,7 +141,7 @@ int main( int argc, char **argv )
         // finish line
         printf("\n");
     }
-    
+
     // success
     return 0 ;
 }


### PR DESCRIPTION
While comparing the performance of this version with this with the TensorFlow version I realized that this version was doing much more work.  In particular, much as the same samples are reused across columns/powers (because the columns don't need to be independent from each other), they can be used across rows/dimensions.  You can thus calculate a sample in constant time (rather than O(d) time) for the d-dimensional case by reusing the sum from the (d-1)-dimensional case.  This reduces the total running time of the program from O(p * d^2 * r) to O(p * d * r), and appears to speed up the code significantly even for relatively small values of p, d, and r.  